### PR TITLE
Add tab pane for filter actions and improve layouts

### DIFF
--- a/src/main/kotlin/view/CssStyle.kt
+++ b/src/main/kotlin/view/CssStyle.kt
@@ -1,5 +1,6 @@
 package view
 
+import javafx.geometry.Pos
 import tornadofx.*
 
 class CssStyle : Stylesheet() {
@@ -21,6 +22,10 @@ class CssStyle : Stylesheet() {
 
         filterSlider {
             padding = CssBox<Dimension<Dimension.LinearUnits>>(0.px, 10.px, 0.px, 10.px)
+        }
+
+        listCell {
+            alignment = Pos.CENTER
         }
     }
 }

--- a/src/main/kotlin/view/FilterPanel.kt
+++ b/src/main/kotlin/view/FilterPanel.kt
@@ -136,11 +136,13 @@ class FilterPanel : View() {
                         prefWidth = 400.0
                     }
                 }
-
-                buttonbar {
-                    padding = Insets(20.0, 10.0, 20.0, 10.0)
-                    button("Undo").setOnAction { fileController.undo() }
-                    button("Revert").setOnAction { fileController.revert() }
+                hbox {
+                    alignment = Pos.CENTER
+                    buttonbar {
+                        padding = Insets(20.0, 10.0, 20.0, 10.0)
+                        button("Undo").setOnAction { fileController.undo() }
+                        button("Revert").setOnAction { fileController.revert() }
+                    }
                 }
             }
             orientation = Orientation.VERTICAL

--- a/src/main/kotlin/view/FilterPanel.kt
+++ b/src/main/kotlin/view/FilterPanel.kt
@@ -3,6 +3,8 @@ package view
 import controller.EngineController
 import controller.FileController
 import javafx.geometry.Insets
+import javafx.geometry.Orientation
+import javafx.geometry.Pos
 import javafx.geometry.Side
 import javafx.scene.control.TabPane
 import javafx.scene.text.FontWeight
@@ -47,92 +49,102 @@ class FilterPanel : View() {
     )
 
     override val root = vbox {
-        tabpane {
-            tabClosingPolicy = TabPane.TabClosingPolicy.UNAVAILABLE
-            side = Side.LEFT
-            tab("Basic Actions") {
-                vbox {
-                    label("Basic Actions") {
-                        vboxConstraints {
-                            margin = Insets(20.0, 20.0, 10.0, 10.0)
-                        }
-                        style {
-                            fontWeight = FontWeight.BOLD
-                            fontSize = Dimension(20.0, Dimension.LinearUnits.px)
-
-                        }
-                    }
-
-                    hbox {
-                        padding = Insets(0.0, 10.0, 0.0, 10.0)
-                        buttonbar {
-                            basicFilterButtonList.map { (s, callback) -> button(s).setOnAction { callback() } }
-                        }
-                    }
-                }
-            }
-            tab("RGB") {
-                vbox {
-                    label("Advanced Actions - RGB") {
-                        vboxConstraints {
-                            margin = Insets(20.0, 20.0, 10.0, 10.0)
-                        }
-                        style {
-                            fontWeight = FontWeight.BOLD
-                            fontSize = Dimension(20.0, Dimension.LinearUnits.px)
-                        }
-                    }
-
+        splitpane {
+            tabpane {
+                tabClosingPolicy = TabPane.TabClosingPolicy.UNAVAILABLE
+                side = Side.LEFT
+                tab("Basic Actions") {
                     vbox {
-                        vboxConstraints {
-                            margin = Insets(10.0)
+                        label("Basic Actions") {
+                            vboxConstraints {
+                                margin = Insets(20.0, 20.0, 10.0, 10.0)
+                            }
+                            style {
+                                fontWeight = FontWeight.BOLD
+                                fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+
+                            }
                         }
 
-                        basicFilterSliderList.map { (label, op) ->
-                            hbox {
-                                label(label) {
-                                    addClass(CssStyle.labelTag)
-                                }
-                                val slider = slider {
-                                    min = 0.0
-                                    max = 100.0
-                                }
-                                slider.value = 100.0
-                                slider.valueChangingProperty()
-                                    .addListener(ChangeListener { _, _, _ -> op(slider.value / 100) })
-
-                                addClass(CssStyle.filterSlider)
+                        hbox {
+                            padding = Insets(20.0, 20.0, 10.0, 10.0)
+                            buttonbar {
+                                basicFilterButtonList.map { (s, callback) -> button(s).setOnAction { callback() } }
                             }
                         }
                     }
                 }
+                tab("RGB") {
+                    vbox {
+                        label("Advanced Actions - RGB") {
+                            vboxConstraints {
+                                margin = Insets(20.0, 20.0, 10.0, 10.0)
+                            }
+                            style {
+                                fontWeight = FontWeight.BOLD
+                                fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+                            }
+                        }
 
-            }
+                        vbox {
+                            vboxConstraints {
+                                margin = Insets(10.0)
+                            }
 
-            tab("HSV") {
+                            basicFilterSliderList.map { (label, op) ->
+                                hbox {
+                                    padding = Insets(20.0, 20.0, 10.0, 10.0)
+                                    label(label) {
+                                        addClass(CssStyle.labelTag)
+                                    }
+                                    val slider = slider {
+                                        min = 0.0
+                                        max = 100.0
+                                    }
+                                    slider.value = 100.0
+                                    slider.valueChangingProperty()
+                                        .addListener(ChangeListener { _, _, _ -> op(slider.value / 100) })
 
-            }
-        }
-        vbox {
-            buttonbar {
-                button("Undo").setOnAction { fileController.undo() }
-                button("Revert").setOnAction { fileController.revert() }
-            }
+                                    addClass(CssStyle.filterSlider)
+                                }
+                            }
+                        }
+                    }
 
-            label("Transformations") {
-                vboxConstraints {
-                    margin = Insets(20.0, 20.0, 10.0, 10.0)
                 }
-                style {
-                    fontWeight = FontWeight.BOLD
-                    fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+
+                tab("HSV") {
+
                 }
             }
+            vbox {
+                alignment = Pos.CENTER
+                label("Transformations") {
+                    vboxConstraints {
+                        margin = Insets(10.0, 20.0, 10.0, 10.0)
+                    }
+                    style {
+                        fontWeight = FontWeight.BOLD
+                        fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+                    }
+                }
 
-            hbox {
-                padding = Insets(0.0, 10.0, 0.0, 10.0)
-                listview(engine.transformations)
+                hbox {
+                    alignment = Pos.CENTER
+                    padding = Insets(0.0, 10.0, 0.0, 10.0)
+                    listview(engine.transformations) {
+                        prefWidth = 400.0
+                    }
+                }
+
+                buttonbar {
+                    padding = Insets(20.0, 10.0, 20.0, 10.0)
+                    button("Undo").setOnAction { fileController.undo() }
+                    button("Revert").setOnAction { fileController.revert() }
+                }
             }
+            orientation = Orientation.VERTICAL
+            setDividerPosition(0, 0.4)
         }
     }
 }

--- a/src/main/kotlin/view/FilterPanel.kt
+++ b/src/main/kotlin/view/FilterPanel.kt
@@ -3,12 +3,15 @@ package view
 import controller.EngineController
 import controller.FileController
 import javafx.geometry.Insets
+import javafx.geometry.Side
+import javafx.scene.control.TabPane
 import javafx.scene.text.FontWeight
 import models.EngineModel
 import processing.RGBType
 import tornadofx.*
 
 class FilterPanel : View() {
+
 
     private val engine: EngineModel by inject()
     private val engineController: EngineController by inject()
@@ -44,74 +47,92 @@ class FilterPanel : View() {
     )
 
     override val root = vbox {
-        label("Quick Action") {
-            vboxConstraints {
-                margin = Insets(20.0, 20.0, 10.0, 10.0)
-            }
-            style {
-                fontWeight = FontWeight.BOLD
-                fontSize = Dimension(20.0, Dimension.LinearUnits.px)
-            }
-        }
+        tabpane {
+            tabClosingPolicy = TabPane.TabClosingPolicy.UNAVAILABLE
+            side = Side.LEFT
+            tab("Basic Actions") {
+                vbox {
+                    label("Basic Actions") {
+                        vboxConstraints {
+                            margin = Insets(20.0, 20.0, 10.0, 10.0)
+                        }
+                        style {
+                            fontWeight = FontWeight.BOLD
+                            fontSize = Dimension(20.0, Dimension.LinearUnits.px)
 
-        hbox {
-            padding = Insets(0.0, 10.0, 0.0, 10.0)
-            buttonbar {
-                basicFilterButtonList.map { (s, callback) -> button(s).setOnAction { callback() } }
-            }
-        }
-
-        label("Quick Action") {
-            vboxConstraints {
-                margin = Insets(20.0, 20.0, 10.0, 10.0)
-            }
-            style {
-                fontWeight = FontWeight.BOLD
-                fontSize = Dimension(20.0, Dimension.LinearUnits.px)
-            }
-        }
-
-        vbox {
-            vboxConstraints {
-                margin = Insets(10.0)
-            }
-
-            basicFilterSliderList.map { (label, op) ->
-                hbox {
-                    label(label) {
-                        addClass(CssStyle.labelTag)
+                        }
                     }
-                    val slider = slider {
-                        min = 0.0
-                        max = 100.0
-                    }
-                    slider.value = 100.0
-                    slider.valueChangingProperty()
-                        .addListener(ChangeListener { _, _, _ -> op(slider.value / 100) })
 
-                    addClass(CssStyle.filterSlider)
+                    hbox {
+                        padding = Insets(0.0, 10.0, 0.0, 10.0)
+                        buttonbar {
+                            basicFilterButtonList.map { (s, callback) -> button(s).setOnAction { callback() } }
+                        }
+                    }
                 }
             }
-        }
-        buttonbar {
-            button("Undo").setOnAction { fileController.undo() }
-            button("Revert").setOnAction { fileController.revert() }
-        }
+            tab("RGB") {
+                vbox {
+                    label("Advanced Actions - RGB") {
+                        vboxConstraints {
+                            margin = Insets(20.0, 20.0, 10.0, 10.0)
+                        }
+                        style {
+                            fontWeight = FontWeight.BOLD
+                            fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+                        }
+                    }
 
-        label("Transformations") {
-            vboxConstraints {
-                margin = Insets(20.0, 20.0, 10.0, 10.0)
+                    vbox {
+                        vboxConstraints {
+                            margin = Insets(10.0)
+                        }
+
+                        basicFilterSliderList.map { (label, op) ->
+                            hbox {
+                                label(label) {
+                                    addClass(CssStyle.labelTag)
+                                }
+                                val slider = slider {
+                                    min = 0.0
+                                    max = 100.0
+                                }
+                                slider.value = 100.0
+                                slider.valueChangingProperty()
+                                    .addListener(ChangeListener { _, _, _ -> op(slider.value / 100) })
+
+                                addClass(CssStyle.filterSlider)
+                            }
+                        }
+                    }
+                }
+
             }
-            style {
-                fontWeight = FontWeight.BOLD
-                fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+
+            tab("HSV") {
+
             }
         }
+        vbox {
+            buttonbar {
+                button("Undo").setOnAction { fileController.undo() }
+                button("Revert").setOnAction { fileController.revert() }
+            }
 
-        hbox {
-            padding = Insets(0.0, 10.0, 0.0, 10.0)
-            listview(engine.transformations)
+            label("Transformations") {
+                vboxConstraints {
+                    margin = Insets(20.0, 20.0, 10.0, 10.0)
+                }
+                style {
+                    fontWeight = FontWeight.BOLD
+                    fontSize = Dimension(20.0, Dimension.LinearUnits.px)
+                }
+            }
+
+            hbox {
+                padding = Insets(0.0, 10.0, 0.0, 10.0)
+                listview(engine.transformations)
+            }
         }
-
     }
 }

--- a/src/main/kotlin/view/TopBar.kt
+++ b/src/main/kotlin/view/TopBar.kt
@@ -2,7 +2,6 @@ package view
 
 import controller.FileController
 import javafx.scene.control.Alert
-import javafx.scene.layout.Priority
 import javafx.stage.FileChooser
 import tornadofx.*
 import java.io.File

--- a/src/main/kotlin/view/TopBar.kt
+++ b/src/main/kotlin/view/TopBar.kt
@@ -10,8 +10,6 @@ import java.io.File
 class TopBar : View() {
     private val fileController: FileController by inject()
 
-    private val viewMode: String = "Basic Actions"
-
     override val root = menubar {
         menu("_File") {
             item("_Import...") {

--- a/src/main/kotlin/view/TopBar.kt
+++ b/src/main/kotlin/view/TopBar.kt
@@ -2,6 +2,7 @@ package view
 
 import controller.FileController
 import javafx.scene.control.Alert
+import javafx.scene.control.ButtonType
 import javafx.stage.FileChooser
 import tornadofx.*
 import java.io.File
@@ -22,7 +23,16 @@ class TopBar : View() {
                     imageOperation(mode = "export")
                 }
             }
-            item("_Quit")
+            item("_Quit") {
+                action {
+                    val result = alert(
+                        type = Alert.AlertType.CONFIRMATION,
+                        header = "Confirm Quit",
+                        content = "Are you sure you want to quit?"
+                    ).result
+                    if (result == ButtonType.OK) close()
+                }
+            }
         }
 //        menu("_View") {
 //            item("_Basic Actions") {
@@ -34,7 +44,7 @@ class TopBar : View() {
 //            item("_HSV")
 //        }
         menu("_Help") {
-            item("How to")
+            item("_How to")
         }
     }
 

--- a/src/main/kotlin/view/TopBar.kt
+++ b/src/main/kotlin/view/TopBar.kt
@@ -11,26 +11,32 @@ import java.io.File
 class TopBar : View() {
     private val fileController: FileController by inject()
 
+    private val viewMode: String = "Basic Actions"
+
     override val root = menubar {
-        menu("File") {
-            item("Import...") {
+        menu("_File") {
+            item("_Import...") {
                 action {
                     imageOperation(mode = "import")
                 }
             }
-            item("Export...") {
+            item("_Export...") {
                 action {
                     imageOperation(mode = "export")
                 }
             }
-            item("Quit")
+            item("_Quit")
         }
-        menu("View") {
-            item("Basic Action")
-            item("Advanced")
-            item("Advanced")
-        }
-        menu("Help") {
+//        menu("_View") {
+//            item("_Basic Actions") {
+//                action {
+//
+//                }
+//            }
+//            item("_RGB")
+//            item("_HSV")
+//        }
+        menu("_Help") {
             item("How to")
         }
     }


### PR DESCRIPTION
- [x] Add tab panes for different actions (Basic, RGB, HSV, etc.), removed the `view` menu on the top bar.
- [x] Support `alt` (e.g. Windows) shortcut key for menu buttons
- [x] Implement `quit` button in the menu, which will alert user if they confirm quitting the program (not work by directly `alt+F4` or `X` button at the top corner)
- [x] Add a split pane between filter actions and transformation list to improve the layouts, reorder the redo/undo button to make more logical sense
![demo](https://user-images.githubusercontent.com/53740908/138051753-d6b7502f-f34f-4dce-9f95-a2027e756a6b.png)
