### PR TITLE
Enlarge the default window size to avoid clipping image

### DIFF
--- a/src/main/kotlin/ImageProcessor.kt
+++ b/src/main/kotlin/ImageProcessor.kt
@@ -9,6 +9,7 @@ import view.TopBar
 
 class GUI : View("IPEwG") {
     override val root = borderpane {
+        setPrefSize(1100.0, 780.0)
         top<TopBar>()
         left<FilterPanel>()
         center<ImagePanel>()


### PR DESCRIPTION
One line change, set preferred size on start.