### PR TITLE
IP 42 histogram equalisation

### DIFF
--- a/src/main/kotlin/controller/EngineController.kt
+++ b/src/main/kotlin/controller/EngineController.kt
@@ -57,4 +57,6 @@ class EngineController : Controller() {
     fun blur(radius: Int, type: BlurType) = engine.adjust(type.name, radius.toDouble())
 
     fun sharpen() = engine.transform(Sharpen())
+
+    fun histogramEqualization() = engine.transform(HistogramEqualization())
 }

--- a/src/main/kotlin/processing/filters/HistogramEqualization.kt
+++ b/src/main/kotlin/processing/filters/HistogramEqualization.kt
@@ -21,7 +21,6 @@ class HistogramEqualization: ImageProcessing {
         for (i in 0 until height) {
             for (j in 0 until width) {
                 // in this nested for loop, CDF is generated as PDF, transfer to cdf in the next step
-//                val pixel = reader.getColor(j, i).grayscale()
                 val pixel = reader.getColor(j, i)
                 val pixelVal = pixel.red * (PIXEL_RANGE - 1) // -1 for avoid index out off bound
                 pdf[pixelVal.toInt()] += 1

--- a/src/main/kotlin/processing/filters/HistogramEqualization.kt
+++ b/src/main/kotlin/processing/filters/HistogramEqualization.kt
@@ -56,7 +56,7 @@ class HistogramEqualization: ImageProcessing {
     }
 
     override fun toString(): String {
-        return "Applying Histogram Equalization"
+        return "Histogram Equalization"
     }
 
 }

--- a/src/main/kotlin/processing/filters/HistogramEqualization.kt
+++ b/src/main/kotlin/processing/filters/HistogramEqualization.kt
@@ -1,0 +1,56 @@
+package processing.filters
+
+import javafx.scene.image.PixelReader
+import javafx.scene.image.WritableImage
+import javafx.scene.paint.Color
+import processing.ImageProcessing
+
+class HistogramEqualization: ImageProcessing {
+
+    override fun process(image: WritableImage) {
+        // 1. generate pdf of each pixel value, ASSUME image is in gray scale,
+        val reader : PixelReader = image.pixelReader
+        val height = image.height.toInt()
+        val width = image.width.toInt()
+        val PIXEL_RANGE = 256
+        // element at position i in pdf is count of pixel value i in the image
+        var cdf: Array<Int> = Array(PIXEL_RANGE) {0}
+        for (i in 0 until height) {
+            for (j in 0 until width) {
+                // in this nested for loop, CDF is generated as PDF, transfer to cdf in the next step
+                val pixelVal = reader.getColor(i, j).red * (PIXEL_RANGE - 1) // -1 for avoid index out off bound
+                cdf[pixelVal.toInt()] += 1
+            }
+        }
+
+        // 2. generate cdf w.r.t. pdf and record the count of pixel value which is the smallest among all pixel values
+        var cdfMin = 0
+        for (i in 1 until PIXEL_RANGE) {
+            cdf[i] += cdf[i-1]
+            if (cdf[i-1] == 0) {
+                cdfMin = cdf[i]
+            }
+        }
+
+        // 3. generate map from original pixel value to new pixel value
+        val pixelMap: Array<Double> = Array(PIXEL_RANGE) {0.0}
+        for (i in 0 until PIXEL_RANGE) {
+            pixelMap[i] = (cdf[i] - cdfMin).toDouble() / (height * width - cdfMin) * (PIXEL_RANGE - 2) + 1
+        }
+
+        // 4. write back to image
+        val writer = image.pixelWriter
+        for (i in 0 until height) {
+            for (j in 0 until width) {
+                val readPixelVal = reader.getColor(i, j).red * (PIXEL_RANGE - 1)
+                val pixelVal = pixelMap[readPixelVal.toInt()] / PIXEL_RANGE
+                writer.setColor(i, j, Color.color(pixelVal, pixelVal, pixelVal))
+            }
+        }
+    }
+
+    override fun toString(): String {
+        return "Applying Histogram Equalization"
+    }
+
+}

--- a/src/main/kotlin/processing/frequency/FrequencyFilters.kt
+++ b/src/main/kotlin/processing/frequency/FrequencyFilters.kt
@@ -25,9 +25,9 @@ abstract class FrequencyFilters: ImageProcessing{
         for (i in 0 until height) {
             for (j in 0 until width) {
                 val ratio = (-1.0).pow(i + j)
-                matrix[0][i][j].real = reader.getColor(i, j).red * ratio
-                matrix[1][i][j].real = reader.getColor(i, j).green * ratio
-                matrix[2][i][j].real = reader.getColor(i, j).blue * ratio
+                matrix[0][i][j].real = reader.getColor(j, i).red * ratio
+                matrix[1][i][j].real = reader.getColor(j, i).green * ratio
+                matrix[2][i][j].real = reader.getColor(j, i).blue * ratio
             }
         }
 
@@ -70,7 +70,7 @@ abstract class FrequencyFilters: ImageProcessing{
                     matrix[0][x][y].real.coerceIn(0.0, 1.0),
                     matrix[1][x][y].real.coerceIn(0.0, 1.0),
                     matrix[2][x][y].real.coerceIn(0.0, 1.0))
-                writer.setColor(x, y, newColor)
+                writer.setColor(y, x, newColor)
             }
         }
     }

--- a/src/main/kotlin/view/FilterPanel.kt
+++ b/src/main/kotlin/view/FilterPanel.kt
@@ -37,7 +37,8 @@ class FilterPanel : View() {
         "Flip Horizontal" to engineController::flipHorizontal,
         "Flip Vertical" to engineController::flipVertical,
         "Edge Detection" to engineController::edgeDetection,
-        "Sharpen" to engineController::sharpen
+        "Sharpen" to engineController::sharpen,
+        "Histogram Equalization" to engineController::histogramEqualization
     )
 
     private val colorAdjustmentSliderList = mapOf(


### PR DESCRIPTION
Implemented histogram equalization. 

<img width="891" alt="屏幕快照 2021-10-30 20 53 29" src="https://user-images.githubusercontent.com/56657841/139556751-119aa030-abd3-455c-a5dd-da0e134087a5.png">

intro: 
Given a grayscale image, the returned image has greater contrasts. 
Algorithm: count how many times each pixel value occurred, (generate a probability density function), generate cumulative density of the occurrence of each pixel. 'stretch' the cdf so that it is approximately linear shape across the 0-255 range. using the new linear cdf to map each original pixel value to a new value. 

Further work: 
The algorithm first transfers the image to grayscale. Histogram equalization transformation algorithms on coloured image exist but require lots of modification.(as introduced in wiki page 'of colour image' section). 

Reference: 
https://www.youtube.com/watch?v=uqeOrtAzSyU
https://en.wikipedia.org/wiki/Histogram_equalization