### PR TITLE
Ip 35 multithread filter

### DIFF
--- a/src/main/kotlin/processing/filters/Convolution.kt
+++ b/src/main/kotlin/processing/filters/Convolution.kt
@@ -19,16 +19,6 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
     }
 
     override fun process(image: WritableImage) {
-        when (val numCores = Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
         val deviation = kernel.size / 2
         val width = image.width.toInt()
         val height = image.height.toInt()
@@ -75,86 +65,6 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
             }
         }
     }
-
-    private fun multiThreadTask(
-        kernelIndex: Int,
-        image: WritableImage,
-        reader: PixelReader
-    ) {
-        val deviation = kernel.size / 2
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                var sumR = 0.0
-                var sumG = 0.0
-                var sumB = 0.0
-
-                for (i in -deviation..deviation) {
-                    val curY = y + kernelIndex - deviation
-                    val curX = x + i
-                    val factor = kernel[kernelIndex][i + deviation]
-                    if (curY in 0 until image.height.toInt() && curX in 0 until image.width.toInt()) {
-                        sumR += factor * reader.getColor(curX, curY).red
-                        sumG += factor * reader.getColor(curX, curY).green
-                        sumB += factor * reader.getColor(curX, curY).blue
-                    }
-                }
-                image.pixelWriter.setColor(
-                    x, y, Color(
-                        sumR.coerceIn(0.0, 1.0),
-                        sumG.coerceIn(0.0, 1.0),
-                        sumB.coerceIn(0.0, 1.0),
-                        1.0
-                    )
-                )
-            }
-        }
-    }
-
-    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
-        val executors = Executors.newFixedThreadPool(num_threads)
-        val imageList = mutableListOf<WritableImage>()
-
-        for (t in kernel.indices) {
-            val layer = WritableImage(
-                image.pixelReader,
-                image.width.toInt(),
-                image.height.toInt()
-            )
-            imageList.add(layer)
-            executors.execute {
-                multiThreadTask(t, layer, image.pixelReader)
-            }
-        }
-
-        executors.shutdown()
-        executors.awaitTermination(1, TimeUnit.MINUTES)
-
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                image.pixelWriter.setColor(x, y, Color(0.0, 0.0, 0.0, 1.0))
-            }
-        }
-
-        imageList.fold(
-            image
-        ) { curImage, layer ->
-            for (x in 0 until image.width.toInt()) {
-                for (y in 0 until image.height.toInt()) {
-                    val color = layer.pixelReader.getColor(x, y)
-                    val curColor = curImage.pixelReader.getColor(x, y)
-                    val newColor = Color(
-                        (color.red + curColor.red).coerceIn(0.0, 1.0),
-                        (color.green + curColor.green).coerceIn(0.0, 1.0),
-                        (color.blue + curColor.blue).coerceIn(0.0, 1.0),
-                        1.0
-                    )
-                    curImage.pixelWriter.setColor(x, y, newColor)
-                }
-            }
-            curImage
-        }
-    }
-
 
     fun convolutionGreyScaleNegative(image: WritableImage): Array<DoubleArray> {
         val deviation = kernel.size / 2

--- a/src/main/kotlin/processing/filters/Convolution.kt
+++ b/src/main/kotlin/processing/filters/Convolution.kt
@@ -5,6 +5,8 @@ import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import javafx.scene.paint.Color
 import processing.ImageProcessing
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * @param kernel n*n matrix, with odd n
@@ -17,6 +19,16 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
     }
 
     override fun process(image: WritableImage) {
+        when (val numCores = Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
         val deviation = kernel.size / 2
         val width = image.width.toInt()
         val height = image.height.toInt()
@@ -38,9 +50,18 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
                         val currX = x + j
                         val factor = kernel[i + deviation][j + deviation]
                         if (currY in 0 until height && currX in 0 until width) {
-                            sumR += factor * original.pixelReader.getColor(currX, currY).red
-                            sumG += factor * original.pixelReader.getColor(currX, currY).green
-                            sumB += factor * original.pixelReader.getColor(currX, currY).blue
+                            sumR += factor * original.pixelReader.getColor(
+                                currX,
+                                currY
+                            ).red
+                            sumG += factor * original.pixelReader.getColor(
+                                currX,
+                                currY
+                            ).green
+                            sumB += factor * original.pixelReader.getColor(
+                                currX,
+                                currY
+                            ).blue
                         }
                     }
                 }
@@ -52,6 +73,85 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
                 )
                 writer.setColor(x, y, newColor)
             }
+        }
+    }
+
+    private fun multiThreadTask(
+        kernelIndex: Int,
+        image: WritableImage,
+        reader: PixelReader
+    ) {
+        val deviation = kernel.size / 2
+        for (x in 0 until image.width.toInt()) {
+            for (y in 0 until image.height.toInt()) {
+                var sumR = 0.0
+                var sumG = 0.0
+                var sumB = 0.0
+
+                for (i in -deviation..deviation) {
+                    val curY = y + kernelIndex - deviation
+                    val curX = x + i
+                    val factor = kernel[kernelIndex][i + deviation]
+                    if (curY in 0 until image.height.toInt() && curX in 0 until image.width.toInt()) {
+                        sumR += factor * reader.getColor(curX, curY).red
+                        sumG += factor * reader.getColor(curX, curY).green
+                        sumB += factor * reader.getColor(curX, curY).blue
+                    }
+                }
+                image.pixelWriter.setColor(
+                    x, y, Color(
+                        sumR.coerceIn(0.0, 1.0),
+                        sumG.coerceIn(0.0, 1.0),
+                        sumB.coerceIn(0.0, 1.0),
+                        1.0
+                    )
+                )
+            }
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val executors = Executors.newFixedThreadPool(num_threads)
+        val imageList = mutableListOf<WritableImage>()
+
+        for (t in kernel.indices) {
+            val layer = WritableImage(
+                image.pixelReader,
+                image.width.toInt(),
+                image.height.toInt()
+            )
+            imageList.add(layer)
+            executors.execute {
+                multiThreadTask(t, layer, image.pixelReader)
+            }
+        }
+
+        executors.shutdown()
+        executors.awaitTermination(1, TimeUnit.MINUTES)
+
+        for (x in 0 until image.width.toInt()) {
+            for (y in 0 until image.height.toInt()) {
+                image.pixelWriter.setColor(x, y, Color(0.0, 0.0, 0.0, 1.0))
+            }
+        }
+
+        imageList.fold(
+            image
+        ) { curImage, layer ->
+            for (x in 0 until image.width.toInt()) {
+                for (y in 0 until image.height.toInt()) {
+                    val color = layer.pixelReader.getColor(x, y)
+                    val curColor = curImage.pixelReader.getColor(x, y)
+                    val newColor = Color(
+                        (color.red + curColor.red).coerceIn(0.0, 1.0),
+                        (color.green + curColor.green).coerceIn(0.0, 1.0),
+                        (color.blue + curColor.blue).coerceIn(0.0, 1.0),
+                        1.0
+                    )
+                    curImage.pixelWriter.setColor(x, y, newColor)
+                }
+            }
+            curImage
         }
     }
 
@@ -77,7 +177,10 @@ class Convolution(private val kernel: Array<Array<Double>>) : ImageProcessing {
                         val currX = x + j
                         val factor = kernel[i + deviation][j + deviation]
                         if (currY in 0 until height && currX in 0 until width) {
-                            sumR += factor * original.pixelReader.getColor(currX, currY).red
+                            sumR += factor * original.pixelReader.getColor(
+                                currX,
+                                currY
+                            ).red
                         }
                     }
                 }

--- a/src/main/kotlin/processing/filters/FlipHorizontal.kt
+++ b/src/main/kotlin/processing/filters/FlipHorizontal.kt
@@ -4,12 +4,57 @@ import javafx.scene.image.PixelReader
 import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
+import processing.multithread.splitImageHorizontal
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 class FlipHorizontal : ImageProcessing {
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val executorService = Executors.newFixedThreadPool(num_threads)
+        val stripeWidth = (image.height / num_threads).roundToInt()
+
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
 
+        for (i in 0 until num_threads) {
+            val yStart = i * stripeWidth
+            val yEnd = minOf((i + 1) * stripeWidth, image.height.toInt())
+
+            executorService.execute {
+                for (x in 0 until image.width.toInt() / 2) {
+                    for (y in yStart until yEnd) {
+                        val colour =
+                            reader.getColor(image.width.toInt() - x - 1, y)
+                        writer.setColor(
+                            image.width.toInt() - x - 1,
+                            y,
+                            reader.getColor(x, y)
+                        )
+                        writer.setColor(x, y, colour)
+                    }
+                }
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
+        val reader: PixelReader = image.pixelReader
+        val writer: PixelWriter = image.pixelWriter
         for (x in 0 until image.width.toInt() / 2) {
             for (y in 0 until image.height.toInt()) {
                 val colour = reader.getColor(image.width.toInt() - x - 1, y)

--- a/src/main/kotlin/processing/filters/FlipHorizontal.kt
+++ b/src/main/kotlin/processing/filters/FlipHorizontal.kt
@@ -13,13 +13,7 @@ import kotlin.math.roundToInt
 class FlipHorizontal : ImageProcessing {
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
     }
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
@@ -50,22 +44,6 @@ class FlipHorizontal : ImageProcessing {
         }
         executorService.shutdown()
         executorService.awaitTermination(1, TimeUnit.MINUTES)
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt() / 2) {
-            for (y in 0 until image.height.toInt()) {
-                val colour = reader.getColor(image.width.toInt() - x - 1, y)
-                writer.setColor(
-                    image.width.toInt() - x - 1,
-                    y,
-                    reader.getColor(x, y)
-                )
-                writer.setColor(x, y, colour)
-            }
-        }
     }
 
     override fun toString(): String = "Flip Horizontal"

--- a/src/main/kotlin/processing/filters/FlipVertical.kt
+++ b/src/main/kotlin/processing/filters/FlipVertical.kt
@@ -12,13 +12,8 @@ import kotlin.math.roundToInt
 class FlipVertical : ImageProcessing {
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
+
     }
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
@@ -49,22 +44,6 @@ class FlipVertical : ImageProcessing {
         }
         executorService.shutdown()
         executorService.awaitTermination(1, TimeUnit.MINUTES)
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt() / 2) {
-                val colour = reader.getColor(x, image.height.toInt() - y - 1)
-                writer.setColor(
-                    x,
-                    image.height.toInt() - y - 1,
-                    reader.getColor(x, y)
-                )
-                writer.setColor(x, y, colour)
-            }
-        }
     }
 
     override fun toString(): String = "Flip Vertical"

--- a/src/main/kotlin/processing/filters/FlipVertical.kt
+++ b/src/main/kotlin/processing/filters/FlipVertical.kt
@@ -4,12 +4,56 @@ import javafx.scene.image.PixelReader
 import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 class FlipVertical : ImageProcessing {
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val executorService = Executors.newFixedThreadPool(num_threads)
+        val stripeWidth = (image.width / num_threads).roundToInt()
+
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
 
+        for (i in 0 until num_threads) {
+            val xStart = i * stripeWidth
+            val xEnd = minOf((i + 1) * stripeWidth, image.width.toInt())
+
+            executorService.execute {
+                for (x in xStart until xEnd) {
+                    for (y in 0 until image.height.toInt() / 2) {
+                        val colour =
+                            reader.getColor(x, image.height.toInt() - y - 1)
+                        writer.setColor(
+                            x,
+                            image.height.toInt() - y - 1,
+                            reader.getColor(x, y)
+                        )
+                        writer.setColor(x, y, colour)
+                    }
+                }
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
+        val reader: PixelReader = image.pixelReader
+        val writer: PixelWriter = image.pixelWriter
         for (x in 0 until image.width.toInt()) {
             for (y in 0 until image.height.toInt() / 2) {
                 val colour = reader.getColor(x, image.height.toInt() - y - 1)

--- a/src/main/kotlin/processing/filters/Grayscale.kt
+++ b/src/main/kotlin/processing/filters/Grayscale.kt
@@ -12,13 +12,7 @@ import java.util.concurrent.TimeUnit
 class Grayscale : ImageProcessing {
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
     }
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
@@ -54,16 +48,6 @@ class Grayscale : ImageProcessing {
                         partition.image.pixelReader.getColor(x, y)
                     )
                 }
-            }
-        }
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                writer.setColor(x, y, reader.getColor(x, y).grayscale())
             }
         }
     }

--- a/src/main/kotlin/processing/filters/Grayscale.kt
+++ b/src/main/kotlin/processing/filters/Grayscale.kt
@@ -4,12 +4,63 @@ import javafx.scene.image.PixelReader
 import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
+import processing.multithread.splitImageHorizontal
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class Grayscale : ImageProcessing {
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val partitions = splitImageHorizontal(num_threads, image)
+        val executorService = Executors.newFixedThreadPool(num_threads)
+
+        // Divide
+        for (partition in partitions) {
+            executorService.execute {
+                val subImage = partition.image
+                val reader = subImage.pixelReader
+                val writer = subImage.pixelWriter
+
+                for (x in 0 until subImage.width.toInt()) {
+                    for (y in 0 until subImage.height.toInt()) {
+                        writer.setColor(x, y, reader.getColor(x, y).grayscale())
+                    }
+                }
+
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+
+        // Merge & Conquer
+        val writer = image.pixelWriter
+        for (partition in partitions) {
+            for (x in 0 until partition.image.width.toInt()) {
+                for (y in 0 until partition.image.height.toInt()) {
+                    writer.setColor(
+                        x + partition.x1,
+                        y + partition.y1,
+                        partition.image.pixelReader.getColor(x, y)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
-
         for (x in 0 until image.width.toInt()) {
             for (y in 0 until image.height.toInt()) {
                 writer.setColor(x, y, reader.getColor(x, y).grayscale())

--- a/src/main/kotlin/processing/filters/HSVIntensity.kt
+++ b/src/main/kotlin/processing/filters/HSVIntensity.kt
@@ -6,18 +6,95 @@ import javafx.scene.image.WritableImage
 import javafx.scene.paint.Color
 import processing.HSVType
 import processing.ImageProcessing
+import processing.multithread.splitImageHorizontal
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class HSVIntensity(private val factor: Double, private val type: HSVType) :
     ImageProcessing {
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            else -> singleThreadedProcess(image)
+//            else -> multiThreadedProcess(
+//                image,
+//                numCores
+//            )
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val partitions = splitImageVertical(num_threads, image)
+        val executorService = Executors.newFixedThreadPool(num_threads)
+
+        // Divide
+        for (partition in partitions) {
+            executorService.execute {
+                val subImage = partition.image
+                val reader = subImage.pixelReader
+                val writer = subImage.pixelWriter
+
+                for (x in 0 until subImage.width.toInt()) {
+                    for (y in 0 until subImage.height.toInt()) {
+                        val color: Color = reader.getColor(x, y)
+                        val newColor: Color = when (type) {
+                            HSVType.H -> color.deriveColor(
+                                (factor - 1) * 180,
+                                1.0,
+                                1.0,
+                                1.0
+                            )
+                            HSVType.S -> color.deriveColor(
+                                0.0,
+                                factor,
+                                1.0,
+                                1.0
+                            )
+                            HSVType.V -> color.deriveColor(
+                                0.0,
+                                1.0,
+                                factor,
+                                1.0
+                            )
+                        }
+                        writer.setColor(x, y, newColor)
+                    }
+                }
+
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+
+        // Merge & Conquer
+        val writer = image.pixelWriter
+        for (partition in partitions) {
+            for (x in 0 until partition.image.width.toInt()) {
+                for (y in 0 until partition.image.height.toInt()) {
+                    writer.setColor(
+                        x + partition.x1,
+                        y + partition.y1,
+                        partition.image.pixelReader.getColor(x, y)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
-
         for (x in 0 until image.width.toInt()) {
             for (y in 0 until image.height.toInt()) {
                 val color: Color = reader.getColor(x, y)
                 val newColor: Color = when (type) {
-                    HSVType.H -> color.deriveColor((factor - 1) * 180, 1.0, 1.0, 1.0)
+                    HSVType.H -> color.deriveColor(
+                        (factor - 1) * 180,
+                        1.0,
+                        1.0,
+                        1.0
+                    )
                     HSVType.S -> color.deriveColor(0.0, factor, 1.0, 1.0)
                     HSVType.V -> color.deriveColor(0.0, 1.0, factor, 1.0)
                 }

--- a/src/main/kotlin/processing/filters/HSVIntensity.kt
+++ b/src/main/kotlin/processing/filters/HSVIntensity.kt
@@ -15,13 +15,7 @@ class HSVIntensity(private val factor: Double, private val type: HSVType) :
     ImageProcessing {
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
     }
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
@@ -82,26 +76,6 @@ class HSVIntensity(private val factor: Double, private val type: HSVType) :
         }
     }
 
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                val color: Color = reader.getColor(x, y)
-                val newColor: Color = when (type) {
-                    HSVType.H -> color.deriveColor(
-                        (factor - 1) * 180,
-                        1.0,
-                        1.0,
-                        1.0
-                    )
-                    HSVType.S -> color.deriveColor(0.0, factor, 1.0, 1.0)
-                    HSVType.V -> color.deriveColor(0.0, 1.0, factor, 1.0)
-                }
-                writer.setColor(x, y, newColor)
-            }
-        }
-    }
 
     override fun toString(): String = "${type}=${(factor * 100 - 100).toInt()}%"
 }

--- a/src/main/kotlin/processing/filters/HSVIntensity.kt
+++ b/src/main/kotlin/processing/filters/HSVIntensity.kt
@@ -16,11 +16,11 @@ class HSVIntensity(private val factor: Double, private val type: HSVType) :
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
         when (Runtime.getRuntime().availableProcessors()) {
-            else -> singleThreadedProcess(image)
-//            else -> multiThreadedProcess(
-//                image,
-//                numCores
-//            )
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
         }
     }
 

--- a/src/main/kotlin/processing/filters/InverseColour.kt
+++ b/src/main/kotlin/processing/filters/InverseColour.kt
@@ -4,12 +4,88 @@ import javafx.scene.image.PixelReader
 import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 class InverseColour : ImageProcessing {
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun multiThreadNoCopy(image: WritableImage, num_threads: Int) {
+        val executorService = Executors.newFixedThreadPool(num_threads)
+        val stripeWidth = (image.width / num_threads).roundToInt()
+        println(stripeWidth)
+
+        for (i in 0 until num_threads) {
+            executorService.execute {
+                for (x in i * stripeWidth until minOf(
+                    (i + 1) * stripeWidth,
+                    image.width.toInt()
+                )) {
+                    for (y in 0 until image.height.toInt()) {
+                        image.pixelWriter.setColor(
+                            x,
+                            y,
+                            image.pixelReader.getColor(x, y).invert()
+                        )
+                    }
+                }
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val partitions = splitImageVertical(num_threads, image)
+        val executorService = Executors.newFixedThreadPool(num_threads)
+
+        // Divide
+        for (partition in partitions) {
+            executorService.execute {
+                val subImage = partition.image
+                val reader = subImage.pixelReader
+                val writer = subImage.pixelWriter
+
+                for (x in 0 until subImage.width.toInt()) {
+                    for (y in 0 until subImage.height.toInt()) {
+                        writer.setColor(x, y, reader.getColor(x, y).invert())
+                    }
+                }
+
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+
+        // Merge & Conquer
+        val writer = image.pixelWriter
+        for (partition in partitions) {
+            for (x in 0 until partition.image.width.toInt()) {
+                for (y in 0 until partition.image.height.toInt()) {
+                    writer.setColor(
+                        x + partition.x1,
+                        y + partition.y1,
+                        partition.image.pixelReader.getColor(x, y)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
-
         for (x in 0 until image.width.toInt()) {
             for (y in 0 until image.height.toInt()) {
                 writer.setColor(x, y, reader.getColor(x, y).invert())
@@ -19,3 +95,4 @@ class InverseColour : ImageProcessing {
 
     override fun toString(): String = "Inverse Colour"
 }
+

--- a/src/main/kotlin/processing/filters/InverseColour.kt
+++ b/src/main/kotlin/processing/filters/InverseColour.kt
@@ -21,31 +21,6 @@ class InverseColour : ImageProcessing {
         }
     }
 
-    private fun multiThreadNoCopy(image: WritableImage, num_threads: Int) {
-        val executorService = Executors.newFixedThreadPool(num_threads)
-        val stripeWidth = (image.width / num_threads).roundToInt()
-        println(stripeWidth)
-
-        for (i in 0 until num_threads) {
-            executorService.execute {
-                for (x in i * stripeWidth until minOf(
-                    (i + 1) * stripeWidth,
-                    image.width.toInt()
-                )) {
-                    for (y in 0 until image.height.toInt()) {
-                        image.pixelWriter.setColor(
-                            x,
-                            y,
-                            image.pixelReader.getColor(x, y).invert()
-                        )
-                    }
-                }
-            }
-        }
-        executorService.shutdown()
-        executorService.awaitTermination(1, TimeUnit.MINUTES)
-    }
-
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
         val partitions = splitImageVertical(num_threads, image)
         val executorService = Executors.newFixedThreadPool(num_threads)

--- a/src/main/kotlin/processing/filters/InverseColour.kt
+++ b/src/main/kotlin/processing/filters/InverseColour.kt
@@ -12,13 +12,7 @@ import kotlin.math.roundToInt
 class InverseColour : ImageProcessing {
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
     }
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
@@ -54,16 +48,6 @@ class InverseColour : ImageProcessing {
                         partition.image.pixelReader.getColor(x, y)
                     )
                 }
-            }
-        }
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                writer.setColor(x, y, reader.getColor(x, y).invert())
             }
         }
     }

--- a/src/main/kotlin/processing/filters/RGBIntensity.kt
+++ b/src/main/kotlin/processing/filters/RGBIntensity.kt
@@ -4,15 +4,88 @@ import javafx.scene.image.PixelReader
 import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import javafx.scene.paint.Color
+import processing.HSVType
 import processing.ImageProcessing
 import processing.RGBType
+import processing.multithread.splitImageVertical
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class RGBIntensity(private val factor: Double, private val type: RGBType) :
     ImageProcessing {
+
     override fun process(image: WritableImage) {
+        val numCores = Runtime.getRuntime().availableProcessors()
+        when (Runtime.getRuntime().availableProcessors()) {
+            1 -> singleThreadedProcess(image)
+            else -> multiThreadedProcess(
+                image,
+                numCores
+            )
+        }
+    }
+
+    private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
+        val partitions = splitImageVertical(num_threads, image)
+        val executorService = Executors.newFixedThreadPool(num_threads)
+
+        // Divide
+        for (partition in partitions) {
+            executorService.execute {
+                val subImage = partition.image
+                val reader = subImage.pixelReader
+                val writer = subImage.pixelWriter
+
+                for (x in 0 until subImage.width.toInt()) {
+                    for (y in 0 until subImage.height.toInt()) {
+                        val color: Color = reader.getColor(x, y)
+                        val red = color.red
+                        val green = color.green
+                        val blue = color.blue
+                        val newColor: Color = when (type) {
+                            RGBType.R -> Color.color(
+                                (red * factor).coerceAtMost(
+                                    1.0
+                                ), green, blue
+                            )
+                            RGBType.G -> Color.color(
+                                red,
+                                (green * factor).coerceAtMost(1.0),
+                                blue
+                            )
+                            RGBType.B -> Color.color(
+                                red,
+                                green,
+                                (blue * factor).coerceAtMost(1.0)
+                            )
+                        }
+                        writer.setColor(x, y, newColor)
+                    }
+                }
+
+            }
+        }
+        executorService.shutdown()
+        executorService.awaitTermination(1, TimeUnit.MINUTES)
+
+        // Merge & Conquer
+        val writer = image.pixelWriter
+        for (partition in partitions) {
+            for (x in 0 until partition.image.width.toInt()) {
+                for (y in 0 until partition.image.height.toInt()) {
+                    writer.setColor(
+                        x + partition.x1,
+                        y + partition.y1,
+                        partition.image.pixelReader.getColor(x, y)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun singleThreadedProcess(image: WritableImage) {
         val reader: PixelReader = image.pixelReader
         val writer: PixelWriter = image.pixelWriter
-
         for (x in 0 until image.width.toInt()) {
             for (y in 0 until image.height.toInt()) {
                 val color: Color = reader.getColor(x, y)
@@ -20,9 +93,21 @@ class RGBIntensity(private val factor: Double, private val type: RGBType) :
                 val green = color.green
                 val blue = color.blue
                 val newColor: Color = when (type) {
-                    RGBType.R -> Color.color((red * factor).coerceAtMost(1.0), green, blue)
-                    RGBType.G -> Color.color(red, (green * factor).coerceAtMost(1.0), blue)
-                    RGBType.B -> Color.color(red, green, (blue * factor).coerceAtMost(1.0))
+                    RGBType.R -> Color.color(
+                        (red * factor).coerceAtMost(1.0),
+                        green,
+                        blue
+                    )
+                    RGBType.G -> Color.color(
+                        red,
+                        (green * factor).coerceAtMost(1.0),
+                        blue
+                    )
+                    RGBType.B -> Color.color(
+                        red,
+                        green,
+                        (blue * factor).coerceAtMost(1.0)
+                    )
                 }
                 writer.setColor(x, y, newColor)
             }

--- a/src/main/kotlin/processing/filters/RGBIntensity.kt
+++ b/src/main/kotlin/processing/filters/RGBIntensity.kt
@@ -16,14 +16,9 @@ class RGBIntensity(private val factor: Double, private val type: RGBType) :
 
     override fun process(image: WritableImage) {
         val numCores = Runtime.getRuntime().availableProcessors()
-        when (Runtime.getRuntime().availableProcessors()) {
-            1 -> singleThreadedProcess(image)
-            else -> multiThreadedProcess(
-                image,
-                numCores
-            )
-        }
+        multiThreadedProcess(image, numCores)
     }
+
 
     private fun multiThreadedProcess(image: WritableImage, num_threads: Int) {
         val partitions = splitImageVertical(num_threads, image)
@@ -79,37 +74,6 @@ class RGBIntensity(private val factor: Double, private val type: RGBType) :
                         partition.image.pixelReader.getColor(x, y)
                     )
                 }
-            }
-        }
-    }
-
-    private fun singleThreadedProcess(image: WritableImage) {
-        val reader: PixelReader = image.pixelReader
-        val writer: PixelWriter = image.pixelWriter
-        for (x in 0 until image.width.toInt()) {
-            for (y in 0 until image.height.toInt()) {
-                val color: Color = reader.getColor(x, y)
-                val red = color.red
-                val green = color.green
-                val blue = color.blue
-                val newColor: Color = when (type) {
-                    RGBType.R -> Color.color(
-                        (red * factor).coerceAtMost(1.0),
-                        green,
-                        blue
-                    )
-                    RGBType.G -> Color.color(
-                        red,
-                        (green * factor).coerceAtMost(1.0),
-                        blue
-                    )
-                    RGBType.B -> Color.color(
-                        red,
-                        green,
-                        (blue * factor).coerceAtMost(1.0)
-                    )
-                }
-                writer.setColor(x, y, newColor)
             }
         }
     }

--- a/src/main/kotlin/processing/filters/SpatialSeparableConvolution.kt
+++ b/src/main/kotlin/processing/filters/SpatialSeparableConvolution.kt
@@ -1,0 +1,77 @@
+package processing.filters
+
+
+import javafx.scene.image.PixelReader
+import javafx.scene.image.PixelWriter
+import javafx.scene.image.WritableImage
+import javafx.scene.paint.Color
+import processing.ImageProcessing
+
+class SpatialSeparableConvolution(
+    private val kernelCol: Array<Double>,
+    private val kernelRow: Array<Double>
+) : ImageProcessing {
+
+    init {
+        if (kernelCol.size % 2 == 0 || kernelCol.size != kernelRow.size) {
+            throw IllegalArgumentException("ill-formed kernel")
+        }
+    }
+
+    override fun process(image: WritableImage) {
+        alterImage(image, kernelCol)
+        alterImage(image, kernelRow)
+    }
+
+    private fun alterImage(
+        image: WritableImage,
+        vector: Array<Double>,
+    ) {
+        val deviation = vector.size / 2
+        val width = image.width.toInt()
+        val height = image.height.toInt()
+        val reader = image.pixelReader
+        val writer = image.pixelWriter
+        val original = WritableImage(
+            reader,
+            width,
+            height
+        )
+
+        for (x in 0 until width) {
+            for (y in 0 until height) {
+                var sumR = 0.0
+                var sumG = 0.0
+                var sumB = 0.0
+                for (i in -deviation..deviation) {
+                    val currX = x + i
+                    val currY = y + i
+                    val factor = vector[i + deviation]
+                    if (currY in 0 until height && currX in 0 until width) {
+                        sumR += factor * original.pixelReader.getColor(
+                            currX,
+                            currY
+                        ).red
+                        sumG += factor * original.pixelReader.getColor(
+                            currX,
+                            currY
+                        ).green
+                        sumB += factor * original.pixelReader.getColor(
+                            currX,
+                            currY
+                        ).blue
+                    }
+
+                }
+                val newColor = Color(
+                    sumR.coerceIn(0.0, 1.0),
+                    sumG.coerceIn(0.0, 1.0),
+                    sumB.coerceIn(0.0, 1.0),
+                    1.0
+                )
+                writer.setColor(x, y, newColor)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/processing/filters/SpatialSeparableConvolution.kt
+++ b/src/main/kotlin/processing/filters/SpatialSeparableConvolution.kt
@@ -19,13 +19,14 @@ class SpatialSeparableConvolution(
     }
 
     override fun process(image: WritableImage) {
-        alterImage(image, kernelCol)
-        alterImage(image, kernelRow)
+        alterImage(image, kernelCol, transpose=true)
+        alterImage(image, kernelRow, transpose=false)
     }
 
     private fun alterImage(
         image: WritableImage,
         vector: Array<Double>,
+        transpose: Boolean
     ) {
         val deviation = vector.size / 2
         val width = image.width.toInt()
@@ -44,22 +45,13 @@ class SpatialSeparableConvolution(
                 var sumG = 0.0
                 var sumB = 0.0
                 for (i in -deviation..deviation) {
-                    val currX = x + i
-                    val currY = y + i
+                    val currX = if (transpose) x + i else x + i
+                    val currY = if (transpose) y + i else y + i
                     val factor = vector[i + deviation]
                     if (currY in 0 until height && currX in 0 until width) {
-                        sumR += factor * original.pixelReader.getColor(
-                            currX,
-                            currY
-                        ).red
-                        sumG += factor * original.pixelReader.getColor(
-                            currX,
-                            currY
-                        ).green
-                        sumB += factor * original.pixelReader.getColor(
-                            currX,
-                            currY
-                        ).blue
+                        sumR += factor * original.pixelReader.getColor(currX, currY).red
+                        sumG += factor * original.pixelReader.getColor(currX, currY).green
+                        sumB += factor * original.pixelReader.getColor(currX, currY).blue
                     }
 
                 }

--- a/src/main/kotlin/processing/filters/blur/BoxBlur.kt
+++ b/src/main/kotlin/processing/filters/blur/BoxBlur.kt
@@ -3,6 +3,7 @@ package processing.filters.blur
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
 import processing.filters.Convolution
+import processing.filters.SpatialSeparableConvolution
 
 class BoxBlur(private val radius: Int) : ImageProcessing {
     override fun process(image: WritableImage) {
@@ -10,14 +11,11 @@ class BoxBlur(private val radius: Int) : ImageProcessing {
             return
         }
         val kernelSize = radius * 2 + 1
-        val kernel = Array(kernelSize) { Array(kernelSize) { 0.0 } }
-        val total = kernelSize * kernelSize
-        for (i in 0 until kernelSize) {
-            for (j in 0 until kernelSize) {
-                kernel[i][j] = 1.0 / total
-            }
-        }
-        Convolution(kernel).process(image)
+
+        SpatialSeparableConvolution(
+            Array(kernelSize) { 1.0 / (kernelSize * kernelSize) },
+            Array(kernelSize) { 1.0 }
+        ).process(image)
     }
 
     override fun toString(): String = "BoxBlur with radius $radius"

--- a/src/main/kotlin/processing/filters/blur/MotionBlur.kt
+++ b/src/main/kotlin/processing/filters/blur/MotionBlur.kt
@@ -2,44 +2,23 @@ package processing.filters.blur
 
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
-import processing.filters.Convolution
+import processing.filters.SpatialSeparableConvolution
 
-class MotionBlur(private val radius: Int, private val angle: Double) : ImageProcessing {
+class MotionBlur(private val radius: Int, private val angle: Double) :
+    ImageProcessing {
     override fun process(image: WritableImage) {
         if (radius == 0) {
             return
         }
         val kernelSize = radius * 2 + 1
-        val kernel = Array(kernelSize) { Array(kernelSize) { 0.0 } }
-        val total = kernelSize
-        val center = radius
-        when (angle) {
-            0.0 -> {
-                for (j in 0 until kernelSize) {
-                    kernel[center][j] = 1.0 / total
-                }
-            }
-            45.0 -> {
-                for (i in 0 until kernelSize) {
-                    kernel[i][kernelSize - i - 1] = 1.0 / total
-                }
-            }
-            90.0 -> {
-                for (i in 0 until kernelSize) {
-                    kernel[i][center] = 1.0 / total
-                }
-            }
-            135.0 -> {
-                for (i in 0 until kernelSize) {
-                    kernel[i][i] = 1.0 / total
-                }
-            }
-            else -> {
-                throw IllegalArgumentException("angle has to be 0, 45, 90 or 135")
-            }
-        }
-        Convolution(kernel).process(image)
+        val column = Array(kernelSize) { 0.0 }
+        column[radius] = 1.0 / kernelSize
+
+        SpatialSeparableConvolution(
+            column, Array(kernelSize) { 1.0 }
+        ).process(image)
     }
 
-    override fun toString(): String = "Motion Blur with radius $radius and angle $angle"
+    override fun toString(): String =
+        "Motion Blur with radius $radius and angle $angle"
 }

--- a/src/main/kotlin/processing/filters/blur/MotionBlur.kt
+++ b/src/main/kotlin/processing/filters/blur/MotionBlur.kt
@@ -2,6 +2,7 @@ package processing.filters.blur
 
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
+import processing.filters.Convolution
 import processing.filters.SpatialSeparableConvolution
 
 class MotionBlur(private val radius: Int, private val angle: Double) :
@@ -11,12 +12,39 @@ class MotionBlur(private val radius: Int, private val angle: Double) :
             return
         }
         val kernelSize = radius * 2 + 1
-        val column = Array(kernelSize) { 0.0 }
-        column[radius] = 1.0 / kernelSize
+        val kernel = Array(kernelSize) { Array(kernelSize) { 0.0 } }
 
-        SpatialSeparableConvolution(
-            column, Array(kernelSize) { 1.0 }
-        ).process(image)
+        when (angle) {
+            0.0 -> {
+                val column = Array(kernelSize) { 0.0 }
+                column[radius] = 1.0
+                SpatialSeparableConvolution(
+                    column, Array(kernelSize) { 1.0 / kernelSize }
+                ).process(image)
+            }
+            45.0 -> {
+                for (i in 0 until kernelSize) {
+                    kernel[i][kernelSize - i - 1] = 1.0 / kernelSize
+                }
+                Convolution(kernel).process(image)
+            }
+            90.0 -> {
+                val row = Array(kernelSize) { 0.0 }
+                row[radius] = 1.0
+                SpatialSeparableConvolution(
+                    Array(kernelSize) { 1.0 / kernelSize }, row
+                ).process(image)
+            }
+            135.0 -> {
+                for (i in 0 until kernelSize) {
+                    kernel[i][i] = 1.0 / kernelSize
+                }
+                Convolution(kernel).process(image)
+            }
+            else -> {
+                throw IllegalArgumentException("angle has to be 0, 45, 90 or 135")
+            }
+        }
     }
 
     override fun toString(): String =

--- a/src/main/kotlin/processing/multithread/utils.kt
+++ b/src/main/kotlin/processing/multithread/utils.kt
@@ -1,0 +1,55 @@
+package processing.multithread
+
+import javafx.scene.image.Image
+import javafx.scene.image.WritableImage
+import kotlin.math.roundToInt
+
+data class ImagePartition(
+    val x1: Int,
+    val y1: Int,
+    val image: WritableImage
+)
+
+fun splitImageVertical(n_splits: Int, image: Image): List<ImagePartition> =
+    mutableListOf<ImagePartition>().apply {
+        val stripeWidth = (image.width / n_splits).roundToInt()
+
+        for (i in 0 until n_splits) {
+            val imagePartition = WritableImage(
+                image.pixelReader,
+                i * stripeWidth,
+                0,
+                minOf(stripeWidth, image.width.toInt() - i * stripeWidth),
+                image.height.toInt()
+            )
+            add(
+                ImagePartition(
+                    i * stripeWidth,
+                    0,
+                    imagePartition
+                )
+            )
+        }
+    }
+
+fun splitImageHorizontal(n_splits: Int, image: Image): List<ImagePartition> =
+    mutableListOf<ImagePartition>().apply {
+        val stripeHeight = (image.height / n_splits).roundToInt()
+
+        for (i in 0 until n_splits) {
+            val imagePartition = WritableImage(
+                image.pixelReader,
+                0,
+                i * stripeHeight,
+                image.width.toInt(),
+                minOf(stripeHeight, image.height.toInt() - i * stripeHeight)
+            )
+            add(
+                ImagePartition(
+                    0,
+                    i * stripeHeight,
+                    imagePartition
+                )
+            )
+        }
+    }

--- a/src/main/kotlin/processing/multithread/utils.kt
+++ b/src/main/kotlin/processing/multithread/utils.kt
@@ -4,6 +4,10 @@ import javafx.scene.image.Image
 import javafx.scene.image.WritableImage
 import kotlin.math.roundToInt
 
+/*
+ * (`x1`, `y1`) denotes the coordinates of the partition relative to
+ * the original image
+ */
 data class ImagePartition(
     val x1: Int,
     val y1: Int,


### PR DESCRIPTION
Implemented the following:
- [X] Simple multithreading operations for non-convolution by splitting up the image into chunks. Most noticeable when applying lots of RGB HSV filters and for large images
- [X] Spatial Separable Convolution - cases when the kernel can be decomposed into a single multiplication of 2 vectors. This reduces the computation

Not included:
- Depthwise Separable convolution (next PR)