### PR TITLE
Ip 52 fft padding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation("org.pytorch:pytorch_java_only:1.9.0")
     implementation("com.facebook.soloader:nativeloader:0.10.1")
     implementation("com.facebook.fbjni:fbjni-java-only:0.2.2")
-    implementation("io.wavebeans:lib:0.3.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.5.31")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.pytorch:pytorch_java_only:1.9.0")
     implementation("com.facebook.soloader:nativeloader:0.10.1")
     implementation("com.facebook.fbjni:fbjni-java-only:0.2.2")
+    implementation("io.wavebeans:lib:0.3.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.5.31")
 

--- a/src/main/kotlin/models/EngineModel.kt
+++ b/src/main/kotlin/models/EngineModel.kt
@@ -2,13 +2,16 @@ package models
 
 import javafx.beans.property.SimpleObjectProperty
 import javafx.embed.swing.SwingFXUtils
+import javafx.geometry.Rectangle2D
 import javafx.scene.image.Image
 import javafx.scene.image.ImageView
 import javafx.scene.image.WritableImage
 import processing.ImageProcessing
 import processing.filters.Adjustment
 import tornadofx.ViewModel
+import tornadofx.imageview
 import tornadofx.observableListOf
+import view.ImagePanel
 import java.io.File
 import java.io.IOException
 import javax.imageio.ImageIO
@@ -40,10 +43,27 @@ class EngineModel(
     private val snapshots = mutableListOf<WritableImage>()
     var currIndex = -1
 
+    // all view components using this model, assigned in view port initialization
+    var imagePanels = observableListOf<ImagePanel>()
+
+    fun addImagePanel(imagePanel: ImagePanel) {
+        imagePanels.add(imagePanel)
+    }
+
     fun load(path: String) {
         val image = Image(path)
         originalImage.value = image
         previewImage.value = image
+        for (imagePanel in imagePanels) {
+            // update all image panel view ports, so that previous image viewport will be overwritten
+            val viewport = Rectangle2D(
+                .0,
+                .0,
+                image.width,
+                image.height,
+            )
+            imagePanel.updateViewPort(viewport)
+        }
 
         currIndex = -1
         transformations.clear()

--- a/src/main/kotlin/processing/frequency/FrequencyFilters.kt
+++ b/src/main/kotlin/processing/frequency/FrequencyFilters.kt
@@ -9,6 +9,8 @@ import processing.ImageProcessing
 import kotlin.math.abs
 import kotlin.math.pow
 import kotlin.math.sqrt
+import org.pytorch.Tensor
+import io.wavebeans.lib.stream.fft.*
 
 abstract class FrequencyFilters: ImageProcessing{
 
@@ -17,17 +19,20 @@ abstract class FrequencyFilters: ImageProcessing{
 
     override fun process(image: WritableImage) {
         // 1. multiplt by (-1)^(i+j) to move top left of image to center
+        //    and pad the image to side length of power of 2
         val reader : PixelReader = image.pixelReader
-        val height = image.height.toInt()
-        val width = image.width.toInt()
+        val ori_height = image.height.toInt()
+        val ori_width = image.width.toInt()
+        val height = nextPow2(ori_height)
+        val width = nextPow2(ori_width)
         val matrix : Array<Array<Array<Complex>>>
             = Array(3) {Array(height) { Array(width) { Complex() }}}
-        for (i in 0 until height) {
-            for (j in 0 until width) {
+        for (i in 0 until ori_height) {
+            for (j in 0 until ori_width) {
                 val ratio = (-1.0).pow(i + j)
-                matrix[0][i][j].real = reader.getColor(i, j).red * ratio
-                matrix[1][i][j].real = reader.getColor(i, j).green * ratio
-                matrix[2][i][j].real = reader.getColor(i, j).blue * ratio
+                matrix[0][i][j].real = reader.getColor(j, i).red * ratio
+                matrix[1][i][j].real = reader.getColor(j, i).green * ratio
+                matrix[2][i][j].real = reader.getColor(j, i).blue * ratio
             }
         }
 
@@ -64,13 +69,13 @@ abstract class FrequencyFilters: ImageProcessing{
 
         // 7. write matrix back to image
         val writer = image.pixelWriter
-        for (x in 0 until  height) {
-            for (y in 0 until  width) {
+        for (x in 0 until ori_height) {
+            for (y in 0 until ori_width) {
                 val newColor: Color = Color.color(
                     matrix[0][x][y].real.coerceIn(0.0, 1.0),
                     matrix[1][x][y].real.coerceIn(0.0, 1.0),
                     matrix[2][x][y].real.coerceIn(0.0, 1.0))
-                writer.setColor(x, y, newColor)
+                writer.setColor(y, x, newColor)
             }
         }
     }
@@ -101,9 +106,17 @@ abstract class FrequencyFilters: ImageProcessing{
         return matrix
     }
 
+    // return the value greater or equal to the given value of power 2
+    private fun nextPow2(n: Int): Int{
+        var power = 1
+        while (power < n) {
+            power *= 2
+        }
+        return power
+    }
+
     // return fft result on given array, ASSUMED the length of array is power of 2
     // References: https://www.bilibili.com/video/BV1za411F76U
-    // todo: remove the constrain of length of array can only be power of 2
     // power = (-2 * pi * i) or (2 * pi * i)
     private fun _fft(array: Array<Complex>, power: Complex, scalar: Double): Array<Complex> {
         val length = array.size

--- a/src/main/kotlin/processing/frequency/FrequencyFilters.kt
+++ b/src/main/kotlin/processing/frequency/FrequencyFilters.kt
@@ -3,14 +3,8 @@ package processing.frequency
 import javafx.scene.image.PixelReader
 import javafx.scene.image.WritableImage
 import javafx.scene.paint.Color
-import processing.FreqProcessRange
-import processing.FreqProcessType
 import processing.ImageProcessing
-import kotlin.math.abs
 import kotlin.math.pow
-import kotlin.math.sqrt
-import org.pytorch.Tensor
-import io.wavebeans.lib.stream.fft.*
 
 abstract class FrequencyFilters: ImageProcessing{
 
@@ -21,14 +15,14 @@ abstract class FrequencyFilters: ImageProcessing{
         // 1. multiplt by (-1)^(i+j) to move top left of image to center
         //    and pad the image to side length of power of 2
         val reader : PixelReader = image.pixelReader
-        val ori_height = image.height.toInt()
-        val ori_width = image.width.toInt()
-        val height = nextPow2(ori_height)
-        val width = nextPow2(ori_width)
+        val oriHeight = image.height.toInt()
+        val oriWidth = image.width.toInt()
+        val height = nextPow2(oriHeight)
+        val width = nextPow2(oriWidth)
         val matrix : Array<Array<Array<Complex>>>
             = Array(3) {Array(height) { Array(width) { Complex() }}}
-        for (i in 0 until ori_height) {
-            for (j in 0 until ori_width) {
+        for (i in 0 until oriHeight) {
+            for (j in 0 until oriWidth) {
                 val ratio = (-1.0).pow(i + j)
                 matrix[0][i][j].real = reader.getColor(j, i).red * ratio
                 matrix[1][i][j].real = reader.getColor(j, i).green * ratio
@@ -69,8 +63,8 @@ abstract class FrequencyFilters: ImageProcessing{
 
         // 7. write matrix back to image
         val writer = image.pixelWriter
-        for (x in 0 until ori_height) {
-            for (y in 0 until ori_width) {
+        for (x in 0 until oriHeight) {
+            for (y in 0 until oriWidth) {
                 val newColor: Color = Color.color(
                     matrix[0][x][y].real.coerceIn(0.0, 1.0),
                     matrix[1][x][y].real.coerceIn(0.0, 1.0),

--- a/src/main/kotlin/view/ImagePanel.kt
+++ b/src/main/kotlin/view/ImagePanel.kt
@@ -18,13 +18,17 @@ class ImagePanel : View() {
     private val engine: EngineModel by inject()
     private var lastMousePoint: Point2D? = null
 
-    private lateinit var oriView: ImageView
-    private lateinit var newView: ImageView
+    lateinit var oriView: ImageView
+    lateinit var newView: ImageView
 
     // Maximum range the left/top pixel coordinate can take,
     // calculated as Image height/width - viewport height/width
     private var excessWidth = 0.0
     var excessHeight = 0.0
+
+    init {
+        engine.addImagePanel(this)
+    }
 
     override val root = vbox {
         stackpane {
@@ -164,7 +168,7 @@ class ImagePanel : View() {
     }
 
     // update both images' viewport in engine
-    private fun updateViewPort(viewPort: Rectangle2D) {
+    fun updateViewPort(viewPort: Rectangle2D) {
         oriView.viewport = viewPort
         newView.viewport = viewPort
         excessWidth = oriView.image.width - viewPort.width


### PR DESCRIPTION
task finished:
- [x] implemented zero padding in frequency filter, so that image of size not power of 2 can also be applied frequency filter. 

bug fixed:
- [x] Previously, if import a new image with height different from width, and zoom out as much as possible. The image will start 'fluctuate' in displaying panel. The bug is due to the newly loaded image is using the viewport of the previous image. Bug fixed by updating both viewports each time when a new image is loaded. 

further work:
- currently frequency filtering is taking relatively long time (~10 sec), can introduce parallel computation to speed up processing.
- There are other ways to implement fft on odd length data, e.g. (https://blogs.uoregon.edu/seis/wiki/unpacking-the-matlab-fft/) (https://stackoverflow.com/questions/42529363/jtransforms-fft-difference-between-even-and-odd-case) I haven't understood either of them, have a look if you are interested in it. 