### PR TITLE
fix(slider-with-spinner): NPE: issue introduced in #33

### DIFF
--- a/src/main/kotlin/view/ImagePanel.kt
+++ b/src/main/kotlin/view/ImagePanel.kt
@@ -26,7 +26,7 @@ class ImagePanel : View() {
     lateinit var oriView: ImageView
     lateinit var newView: ImageView
 
-    lateinit var slider: Slider
+    lateinit var horizontalSlider: Slider
     lateinit var spinner: Spinner<Number>
 
     // Maximum range the left/top pixel coordinate can take,
@@ -39,6 +39,7 @@ class ImagePanel : View() {
     }
 
     override val root = vbox {
+        minWidth = 800.0
         alignment = Pos.CENTER
         stackpane {
             val stack = stackpane {
@@ -164,15 +165,15 @@ class ImagePanel : View() {
         }
 
         // The slider at the bottom of the image view to slide between new and original image.
-        slider = slider {
+        horizontalSlider = slider {
             maxWidth = WINDOW_WIDTH
             min = 0.0
             max = oriView.image.width
             blockIncrement = 1.0
         }
 
-        slider.value = slider.max
-        slider.valueProperty().addListener(ChangeListener { _, _, new ->
+        horizontalSlider.value = horizontalSlider.max
+        horizontalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
             engine.parallelView(new.toDouble())
         })
 
@@ -181,13 +182,13 @@ class ImagePanel : View() {
             max = oriView.image.width,
             amountToStepBy = 1.0,
             editable = true,
-            property = doubleProperty(slider.max)
+            property = doubleProperty(horizontalSlider.max)
         ) {
             maxWidth = 70.0
         }
 
         try {
-            slider.valueProperty().bindBidirectional(
+            horizontalSlider.valueProperty().bindBidirectional(
                 spinner.valueFactory.valueProperty()
             )
         } catch (e: NumberFormatException) {
@@ -197,20 +198,20 @@ class ImagePanel : View() {
     }
 
     fun sliderInit() {
-        slider.value = slider.max
+        horizontalSlider.value = horizontalSlider.max
     }
 
     fun updateSlider(newMax: Double) {
-        slider.max = newMax
-        slider.valueProperty().unbindBidirectional(spinner.valueFactory.valueProperty())
+        horizontalSlider.max = newMax
+        horizontalSlider.valueProperty().unbindBidirectional(spinner.valueFactory.valueProperty())
         @Suppress("UNCHECKED_CAST")
         spinner.valueFactory = SpinnerValueFactory.DoubleSpinnerValueFactory(
-            slider.min,
-            slider.max,
-            slider.blockIncrement
+            horizontalSlider.min,
+            horizontalSlider.max,
+            horizontalSlider.blockIncrement
         ) as SpinnerValueFactory<Number>
         try {
-            slider.valueProperty().bindBidirectional(
+            horizontalSlider.valueProperty().bindBidirectional(
                 spinner.valueFactory.valueProperty()
             )
         } catch (e: NumberFormatException) {

--- a/src/main/kotlin/view/ImagePanel.kt
+++ b/src/main/kotlin/view/ImagePanel.kt
@@ -13,7 +13,7 @@ import javafx.scene.input.ScrollEvent
 import javafx.scene.input.ZoomEvent
 import models.EngineModel
 import tornadofx.*
-import view.component.doubleSpinner
+import view.component.customSpinner
 
 const val WINDOW_W_H_RATIO = 1.0
 const val WINDOW_WIDTH = 600.0
@@ -177,12 +177,13 @@ class ImagePanel : View() {
             engine.parallelView(new.toDouble())
         })
 
-        spinner = doubleSpinner(
+        spinner = customSpinner(
             min = .0,
             max = oriView.image.width,
             amountToStepBy = 1.0,
             editable = true,
-            property = doubleProperty(horizontalSlider.max)
+            property = doubleProperty(horizontalSlider.max),
+            type = "int"
         ) {
             maxWidth = 70.0
         }

--- a/src/main/kotlin/view/component/FrequencyTab.kt
+++ b/src/main/kotlin/view/component/FrequencyTab.kt
@@ -31,10 +31,10 @@ class FrequencyTab(
 
     // slider for adjusting filter parameters
     val passStopBoundSlider =
-        SliderWithSpinner(0.0, 1.0, ChangeListener { _, _, _ -> }, 0.01)
+        SliderWithSpinner(0.0, 1.0, ChangeListener { _, _, _ -> }, 0.1)
             .withLabel("Cutoff Frequency")
     val bandWidthSlider =
-        SliderWithSpinner(0.0, 1.0, ChangeListener { _, _, _ -> }, 0.01)
+        SliderWithSpinner(0.0, 1.0, ChangeListener { _, _, _ -> }, 0.1)
             .withLabel("Band Width")
 
     // input box for butterworth order

--- a/src/main/kotlin/view/component/SliderWithSpinner.kt
+++ b/src/main/kotlin/view/component/SliderWithSpinner.kt
@@ -108,7 +108,7 @@ class SliderWithSpinner(
             isShowTickMarks = true
             majorTickUnit = (maxVal - minVal) / 4
             minorTickCount = 1
-            blockIncrement = 0.1
+            blockIncrement = 1.0
         }
 
         slider.value = 0.0

--- a/src/main/kotlin/view/component/SliderWithSpinner.kt
+++ b/src/main/kotlin/view/component/SliderWithSpinner.kt
@@ -15,7 +15,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.roundToInt
 
-inline fun <reified T : Number> EventTarget.doubleSpinner(
+inline fun <reified T : Number> EventTarget.customSpinner(
     min: T? = null,
     max: T? = null,
     initialValue: T? = null,
@@ -23,6 +23,7 @@ inline fun <reified T : Number> EventTarget.doubleSpinner(
     editable: Boolean = false,
     property: Property<T>? = null,
     enableScroll: Boolean = false,
+    type: String = "double",
     noinline op: Spinner<T>.() -> Unit = {}
 ): Spinner<T> {
     val spinner = spinner(
@@ -49,8 +50,12 @@ inline fun <reified T : Number> EventTarget.doubleSpinner(
                 if (!new.matches(Regex("-?\\d*\\.?\\d*"))) {
                     spinner.editor.text = old
                 } else {
-                    spinner.editor.text =
-                        BigDecimal(new.toDouble()).setScale(1, RoundingMode.HALF_EVEN).toString()
+                    when (type) {
+                        "double" -> spinner.editor.text =
+                            BigDecimal(new.toDouble()).setScale(1, RoundingMode.HALF_EVEN)
+                                .toString()
+                        "int" -> spinner.editor.text = new.toDouble().toInt().toString()
+                    }
                 }
             } catch (e: IllegalArgumentException) {
             }
@@ -110,13 +115,13 @@ class SliderWithSpinner(
         slider.valueProperty().addListener(op)
         this.add(slider)
 
-        spinner = doubleSpinner(
+        spinner = customSpinner(
             min = minVal,
             max = maxVal,
             initialValue = 0.0,
             amountToStepBy = stepSize,
             editable = true,
-            doubleProperty(0.0)
+            doubleProperty(0.0),
         ) {
             maxWidth = 70.0
         }

--- a/src/main/kotlin/view/component/SliderWithSpinner.kt
+++ b/src/main/kotlin/view/component/SliderWithSpinner.kt
@@ -11,6 +11,8 @@ import javafx.scene.control.Spinner
 import javafx.scene.layout.HBox
 import tornadofx.*
 import view.CssStyle
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.math.roundToInt
 
 inline fun <reified T : Number> EventTarget.doubleSpinner(
@@ -48,7 +50,7 @@ inline fun <reified T : Number> EventTarget.doubleSpinner(
                     spinner.editor.text = old
                 } else {
                     spinner.editor.text =
-                        new.toDouble().roundToInt().toString()
+                        BigDecimal(new.toDouble()).setScale(1, RoundingMode.HALF_EVEN).toString()
                 }
             } catch (e: IllegalArgumentException) {
             }
@@ -101,7 +103,7 @@ class SliderWithSpinner(
             isShowTickMarks = true
             majorTickUnit = (maxVal - minVal) / 4
             minorTickCount = 1
-            blockIncrement = 1.0
+            blockIncrement = 0.1
         }
 
         slider.value = 0.0
@@ -118,7 +120,7 @@ class SliderWithSpinner(
         ) {
             maxWidth = 70.0
         }
-        
+
         try {
             slider.valueProperty().bindBidirectional(
                 spinner.valueFactory.valueProperty()

--- a/src/main/kotlin/view/component/SliderWithSpinner.kt
+++ b/src/main/kotlin/view/component/SliderWithSpinner.kt
@@ -108,7 +108,7 @@ class SliderWithSpinner(
         slider.valueProperty().addListener(op)
         this.add(slider)
 
-        spinner = spinner(
+        spinner = doubleSpinner(
             min = minVal,
             max = maxVal,
             initialValue = 0.0,


### PR DESCRIPTION
NPE when user delete number in any spinner in filter tabs (like RGB)

Introduced in f3b073f83ae7436773fb25fa43ee989728d7be43 in #33 
Should use `doubleSpinner` the factored out component rather than raw `spinner`