### PR TITLE
IP-64: Add vertical slider and allow user to select which region to show original image to compare

### DIFF
--- a/src/main/kotlin/models/EngineModel.kt
+++ b/src/main/kotlin/models/EngineModel.kt
@@ -79,7 +79,7 @@ class EngineModel(
                 image.height,
             )
             imagePanel.updateViewPort(viewport)
-            imagePanel.updateSlider(originalImage.value.width)
+            imagePanel.updateSlider(originalImage.value.width, originalImage.value.height)
             imagePanel.sliderInit()
         }
 

--- a/src/main/kotlin/models/EngineModel.kt
+++ b/src/main/kotlin/models/EngineModel.kt
@@ -4,6 +4,7 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.embed.swing.SwingFXUtils
 import javafx.geometry.Rectangle2D
 import javafx.scene.image.Image
+import javafx.scene.image.PixelWriter
 import javafx.scene.image.WritableImage
 import javafx.scene.paint.Color
 import kotlinx.serialization.decodeFromString
@@ -112,7 +113,7 @@ class EngineModel(
         }
     }
 
-    fun parallelView(splitWidth: Double, splitHeight: Double) {
+    fun parallelView(splitWidth: Double, splitHeight: Double, position: String) {
         val output = WritableImage(
             previewImage.get().width.toInt(),
             previewImage.get().height.toInt()
@@ -121,38 +122,67 @@ class EngineModel(
         val newImageReader = previewImage.get().pixelReader
         val outputWriter = output.pixelWriter
 
-        for (x in 0 until splitWidth.toInt()) {
+        // First output whole preview image.
+        for (x in 0 until previewImage.get().width.toInt()) {
             for (y in 0 until previewImage.get().height.toInt()) {
                 outputWriter.setColor(x, y, newImageReader.getColor(x, y))
             }
         }
-        
-        if (splitWidth.toInt() != previewImage.get().width.toInt() || splitHeight.toInt() != previewImage.get().height.toInt()) {
-            for (x in splitWidth.toInt() until originalImage.get().width.toInt()) {
-                for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
-                    outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+
+        // Output original image in given position by user's choice, override previous image.
+        when (position) {
+            "TL" ->
+                for (x in 0 until splitWidth.toInt()) {
+                    for (y in 0 until previewImage.get().height.toInt() - splitHeight.toInt()) {
+                        outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+                    }
                 }
-                for (y in (previewImage.get().height.toInt() - splitHeight.toInt()) until previewImage.get().height.toInt()) {
-                    outputWriter.setColor(x, y, newImageReader.getColor(x, y))
+            "TR" ->
+                for (x in splitWidth.toInt() until previewImage.get().width.toInt()) {
+                    for (y in 0 until previewImage.get().height.toInt() - splitHeight.toInt()) {
+                        outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+                    }
                 }
-            }
+            "BL" ->
+                for (x in 0 until splitWidth.toInt()) {
+                    for (y in previewImage.get().height.toInt() - splitHeight.toInt() until previewImage.get().height.toInt()) {
+                        outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+                    }
+                }
+            "BR" ->
+                for (x in splitWidth.toInt() until previewImage.get().width.toInt()) {
+                    for (y in previewImage.get().height.toInt() - splitHeight.toInt() until previewImage.get().height.toInt()) {
+                        outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+                    }
+                }
         }
 
-        if (splitWidth.toInt() != 0 && splitWidth.toInt() != previewImage.get().width.toInt()) {
-            for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
-                outputWriter.setColor(splitWidth.toInt() - 1, y, Color.BLACK)
-            }
-        }
+//        if (splitWidth.toInt() != previewImage.get().width.toInt() || splitHeight.toInt() != previewImage.get().height.toInt()) {
+//            for (x in splitWidth.toInt() until originalImage.get().width.toInt()) {
+//                for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
+//                    outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+//                }
+//                for (y in (previewImage.get().height.toInt() - splitHeight.toInt()) until previewImage.get().height.toInt()) {
+//                    outputWriter.setColor(x, y, newImageReader.getColor(x, y))
+//                }
+//            }
+//        }
 
-        if (splitHeight.toInt() != 0 && splitHeight.toInt() != previewImage.get().height.toInt()) {
-            for (x in splitWidth.toInt() until previewImage.get().width.toInt()) {
-                outputWriter.setColor(
-                    x,
-                    previewImage.get().height.toInt() - splitHeight.toInt(),
-                    Color.BLACK
-                )
-            }
-        }
+//        if (splitWidth.toInt() != 0 && splitWidth.toInt() != previewImage.get().width.toInt()) {
+//            for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
+//                outputWriter.setColor(splitWidth.toInt() - 1, y, Color.BLACK)
+//            }
+//        }
+//
+//        if (splitHeight.toInt() != 0 && splitHeight.toInt() != previewImage.get().height.toInt()) {
+//            for (x in splitWidth.toInt() until previewImage.get().width.toInt()) {
+//                outputWriter.setColor(
+//                    x,
+//                    previewImage.get().height.toInt() - splitHeight.toInt(),
+//                    Color.BLACK
+//                )
+//            }
+//        }
         parallelImage.value = output
     }
 

--- a/src/main/kotlin/models/EngineModel.kt
+++ b/src/main/kotlin/models/EngineModel.kt
@@ -93,7 +93,7 @@ class EngineModel(
         val image = Image(path)
         encodeImage.value = image
     }
-   
+
     fun loadBlendImage(path: String) {
         val image = Image(path)
         blendImage.value = image
@@ -112,7 +112,7 @@ class EngineModel(
         }
     }
 
-    fun parallelView(splitWidth: Double) {
+    fun parallelView(splitWidth: Double, splitHeight: Double) {
         val output = WritableImage(
             previewImage.get().width.toInt(),
             previewImage.get().height.toInt()
@@ -121,23 +121,36 @@ class EngineModel(
         val newImageReader = previewImage.get().pixelReader
         val outputWriter = output.pixelWriter
 
-        for (x in 0 until splitWidth.toInt() - 1) {
+        for (x in 0 until splitWidth.toInt()) {
             for (y in 0 until previewImage.get().height.toInt()) {
                 outputWriter.setColor(x, y, newImageReader.getColor(x, y))
             }
         }
+        
+        if (splitWidth.toInt() != previewImage.get().width.toInt() || splitHeight.toInt() != previewImage.get().height.toInt()) {
+            for (x in splitWidth.toInt() until originalImage.get().width.toInt()) {
+                for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
+                    outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
+                }
+                for (y in (previewImage.get().height.toInt() - splitHeight.toInt()) until previewImage.get().height.toInt()) {
+                    outputWriter.setColor(x, y, newImageReader.getColor(x, y))
+                }
+            }
+        }
 
         if (splitWidth.toInt() != 0 && splitWidth.toInt() != previewImage.get().width.toInt()) {
-            for (y in 0 until previewImage.get().height.toInt()) {
+            for (y in 0 until (previewImage.get().height.toInt() - splitHeight.toInt())) {
                 outputWriter.setColor(splitWidth.toInt() - 1, y, Color.BLACK)
             }
         }
 
-        if (splitWidth.toInt() != previewImage.get().width.toInt()) {
-            for (x in splitWidth.toInt() until originalImage.get().width.toInt() - 1) {
-                for (y in 0 until originalImage.get().height.toInt()) {
-                    outputWriter.setColor(x, y, oriImageReader.getColor(x, y))
-                }
+        if (splitHeight.toInt() != 0 && splitHeight.toInt() != previewImage.get().height.toInt()) {
+            for (x in splitWidth.toInt() until previewImage.get().width.toInt()) {
+                outputWriter.setColor(
+                    x,
+                    previewImage.get().height.toInt() - splitHeight.toInt(),
+                    Color.BLACK
+                )
             }
         }
         parallelImage.value = output

--- a/src/main/kotlin/view/ImagePanel.kt
+++ b/src/main/kotlin/view/ImagePanel.kt
@@ -30,6 +30,9 @@ class ImagePanel : View() {
 
     lateinit var stack: StackPane
 
+    // The region of (TL, TR, BL, BR) to show the position of the original image in parallel view.
+    lateinit var comparePosition: String
+
     // Maximum range the left/top pixel coordinate can take,
     // calculated as Image height/width - viewport height/width
     private var excessWidth = 0.0
@@ -39,10 +42,19 @@ class ImagePanel : View() {
         engine.addImagePanel(this)
     }
 
-    override val root = hbox {
-        minWidth = BODY_WIDTH
+    override val root = vbox {
+        vboxConstraints {
+            margin = Insets(20.0)
+            spacing = 10.0
+        }
         alignment = Pos.CENTER
-        vbox {
+        minWidth = BODY_WIDTH
+        comparePosition = "TR"
+        hbox {
+            hboxConstraints {
+                margin = Insets(20.0)
+                spacing = 10.0
+            }
             alignment = Pos.CENTER
             stack = stackpane {
                 oriView = imageview(engine.originalImage) {
@@ -163,83 +175,153 @@ class ImagePanel : View() {
             this.minHeight = WINDOW_WIDTH / oriView.image.width * oriView.image.height
             this.maxHeight = WINDOW_WIDTH / oriView.image.width * oriView.image.height
 
-            vboxConstraints {
-                margin = Insets(20.0)
-                spacing = 10.0
-            }
-
-            // The slider at the bottom of the image view to slide between new and original image.
-            horizontalSlider = slider {
-                maxWidth = WINDOW_WIDTH
+            // The slider at the side of the image view to slide between new and original image.
+            verticalSlider = slider {
+                maxHeight = oriView.image.height * 1.2
                 min = 0.0
                 max = oriView.image.width
                 blockIncrement = 1.0
+                orientation = Orientation.VERTICAL
             }
 
-            horizontalSlider.value = horizontalSlider.max
-            horizontalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
-                engine.parallelView(new.toDouble(), verticalSlider.value)
+            verticalSlider.value = verticalSlider.max
+            verticalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
+                engine.parallelView(horizontalSlider.value, new.toDouble(), comparePosition)
             })
 
-            horizontalSpinner = customSpinner(
+            verticalSpinner = customSpinner(
                 min = .0,
                 max = Double.MAX_VALUE,
                 amountToStepBy = 1.0,
                 editable = true,
-                property = doubleProperty(horizontalSlider.max),
+                property = doubleProperty(verticalSlider.max),
                 type = "int"
             ) {
                 maxWidth = 70.0
+                minWidth = 70.0
             }
 
             try {
-                horizontalSlider.valueProperty().bindBidirectional(
-                    horizontalSpinner.valueFactory.valueProperty()
+                verticalSlider.valueProperty().bindBidirectional(
+                    verticalSpinner.valueFactory.valueProperty()
                 )
             } catch (e: NumberFormatException) {
             }
 
-            this.add(horizontalSpinner)
-        }
+            this.add(verticalSpinner)
 
-        hboxConstraints {
-            margin = Insets(20.0)
-            spacing = 10.0
         }
-
-        // The slider at the side of the image view to slide between new and original image.
-        verticalSlider = slider {
-            maxHeight = oriView.image.height * 1.2
+        // The slider at the bottom of the image view to slide between new and original image.
+        horizontalSlider = slider {
+            maxWidth = WINDOW_WIDTH
             min = 0.0
             max = oriView.image.width
             blockIncrement = 1.0
-            orientation = Orientation.VERTICAL
         }
 
-        verticalSlider.value = verticalSlider.max
-        verticalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
-            engine.parallelView(horizontalSlider.value, new.toDouble())
+        horizontalSlider.value = horizontalSlider.max
+        horizontalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
+            engine.parallelView(new.toDouble(), verticalSlider.value, comparePosition)
         })
 
-        verticalSpinner = customSpinner(
+        horizontalSpinner = customSpinner(
             min = .0,
             max = Double.MAX_VALUE,
             amountToStepBy = 1.0,
             editable = true,
-            property = doubleProperty(verticalSlider.max),
+            property = doubleProperty(horizontalSlider.max),
             type = "int"
         ) {
             maxWidth = 70.0
+            minWidth = 70.0
         }
 
         try {
-            verticalSlider.valueProperty().bindBidirectional(
-                verticalSpinner.valueFactory.valueProperty()
+            horizontalSlider.valueProperty().bindBidirectional(
+                horizontalSpinner.valueFactory.valueProperty()
             )
         } catch (e: NumberFormatException) {
         }
+        
+        hbox {
+            alignment = Pos.CENTER
+            spacing = 10.0
+            this.add(horizontalSpinner)
 
-        this.add(verticalSpinner)
+            vbox {
+                alignment = Pos.CENTER
+                spacing = 10.0
+                togglegroup {
+                    hbox {
+                        alignment = Pos.CENTER
+                        // TL
+                        radiobutton {
+                            toggleGroup = this.parent.parent.getToggleGroup()
+                            spacing = 5.0
+                            this.selectedProperty().addListener(ChangeListener { _, _, _ ->
+                                if (isSelected) {
+                                    comparePosition = "TL"
+                                    engine.parallelView(
+                                        horizontalSlider.value,
+                                        verticalSlider.value,
+                                        comparePosition
+                                    )
+                                }
+                            })
+                        }
+                        // TR
+                        radiobutton {
+                            isSelected = true
+                            toggleGroup = this.parent.parent.getToggleGroup()
+                            spacing = 5.0
+                            this.selectedProperty().addListener(ChangeListener { _, _, _ ->
+                                if (isSelected) {
+                                    comparePosition = "TR"
+                                    engine.parallelView(
+                                        horizontalSlider.value,
+                                        verticalSlider.value,
+                                        comparePosition
+                                    )
+                                }
+                            })
+                        }
+                    }
+                    hbox {
+                        alignment = Pos.CENTER
+                        // BL
+                        radiobutton {
+                            toggleGroup = this.parent.parent.getToggleGroup()
+                            spacing = 5.0
+                            this.selectedProperty().addListener(ChangeListener { _, _, _ ->
+                                if (isSelected) {
+                                    comparePosition = "BL"
+                                    engine.parallelView(
+                                        horizontalSlider.value,
+                                        verticalSlider.value,
+                                        comparePosition
+                                    )
+                                }
+                            })
+                        }
+                        // BR
+                        radiobutton {
+                            toggleGroup = this.parent.parent.getToggleGroup()
+                            spacing = 5.0
+                            this.selectedProperty().addListener(ChangeListener { _, _, _ ->
+                                if (isSelected) {
+                                    comparePosition = "BR"
+                                    engine.parallelView(
+                                        horizontalSlider.value,
+                                        verticalSlider.value,
+                                        comparePosition
+                                    )
+                                }
+                            })
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fun sliderInit() {
@@ -308,3 +390,4 @@ class ImagePanel : View() {
         return value / localToImage
     }
 }
+

--- a/src/main/kotlin/view/ImagePanel.kt
+++ b/src/main/kotlin/view/ImagePanel.kt
@@ -178,7 +178,7 @@ class ImagePanel : View() {
 
             horizontalSlider.value = horizontalSlider.max
             horizontalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
-                engine.parallelView(new.toDouble())
+                engine.parallelView(new.toDouble(), verticalSlider.value)
             })
 
             horizontalSpinner = customSpinner(
@@ -218,7 +218,7 @@ class ImagePanel : View() {
 
         verticalSlider.value = verticalSlider.max
         verticalSlider.valueProperty().addListener(ChangeListener { _, _, new ->
-            engine.parallelView(new.toDouble())
+            engine.parallelView(horizontalSlider.value, new.toDouble())
         })
 
         verticalSpinner = customSpinner(


### PR DESCRIPTION
- [x] Clean up code in `parallelView` in engine to make it easier to read.
- [x] Support new parameter `position` to allow user to choose between `TL`, `TR`, `BL` and `BR`.
- [x] Add 2 x 2 radio buttons to allow user to select in the GUI.
- [ ] The border line in black is temporarily removed, may add back in the future.
- [ ] Bugs: Using `HBox` and `VBox` cause missing alignment of the horizontal slider so it's not aligned in the right place with the image view.